### PR TITLE
Latest SKL, GRUB and Linux

### DIFF
--- a/conf/distro/include/tb-distro-common.conf
+++ b/conf/distro/include/tb-distro-common.conf
@@ -45,4 +45,4 @@ DISTRO_FEATURES_BACKFILL_CONSIDERED += "sysvinit"
 # use TrenchBoot Linux and GRUB
 PREFERRED_PROVIDER_virtual/kernel = "linux-tb"
 PREFERRED_PROVIDER_bootloader/kernel = "grub"
-PREFERRED_VERSION_linux-tb ?= "6.6%"
+PREFERRED_VERSION_linux-tb ?= "6.11%"

--- a/recipes-bsp/grub/grub-tb-common.inc
+++ b/recipes-bsp/grub/grub-tb-common.inc
@@ -1,12 +1,12 @@
-PV = "2.06"
+PV = "2.12"
 
 SRC_URI = " \
            git://github.com/TrenchBoot/grub.git;name=grub;branch=${BRANCH_grub};protocol=https \
            git://github.com/coreutils/gnulib;name=gnulib;branch=${BRANCH_gnulib};protocol=https;destsuffix=git/gnulib \
           "
 
-BRANCH_grub = "intel-txt-aem-2.06"
-SRCREV_grub = "85ccfdc700a1640c148909cbbad777ba6d7d124b"
+BRANCH_grub = "tb-2.12-57-v1"
+SRCREV_grub = "8f2771861b20a34faa02d797c44b1edc4d1592c1"
 
 # We add gnulib to SRC_URI to avoid downloading it during the do_configure().
 # The bootstrap script seems to be smart enough to skip fetching repo again
@@ -27,4 +27,15 @@ do_configure:prepend() {
     cd ${S}
     ${S}/bootstrap
     ${S}/autogen.sh
+}
+
+do_configure:append() {
+    # Work around a workaround in poky!
+    #
+    # Tarballs of 2.12 are missing this file, so poky creates it not taking into
+    # account that this breaks out-of-tree builds: Make finds the file as
+    # "extra_deps.lst" in the source tree for its dependency checking through
+    # VPATH, but shell commands run in the build tree don't check the source
+    # tree and just fail.
+    rm ${S}/grub-core/extra_deps.lst
 }

--- a/recipes-bsp/grub/grub_%.bbappend
+++ b/recipes-bsp/grub/grub_%.bbappend
@@ -6,6 +6,7 @@ SRC_URI += "file://0001-add-root-flag-to-grub-bios-setup.patch"
 
 FILES:${PN}-common += " \
     ${libdir}/grub/i386-pc \
+    ${datadir}/bash-completion \
 "
 
 RDEPENDS:${PN}-common += "diffutils freetype"

--- a/recipes-extended/packagegroups/packagegroup-tb.bb
+++ b/recipes-extended/packagegroups/packagegroup-tb.bb
@@ -20,6 +20,7 @@ RDEPENDS:${PN}-utils += " \
                          util-linux-bash-completion \
                          vim \
                          rsync \
+                         kexec \
                          "
 
 RDEPENDS:${PN}-tests = " \

--- a/recipes-kernel/linux/linux-tb_6.11.bb
+++ b/recipes-kernel/linux/linux-tb_6.11.bb
@@ -2,17 +2,17 @@
 require recipes-kernel/linux/linux-yocto.inc
 
 SUMMARY = "Linux kernel"
-DESCRIPTION = "Linux kernel 6.6.1"
+DESCRIPTION = "Linux kernel 6.11"
 HOMEPAGE = "https://github.com/TrenchBoot/linux"
 SECTION = "kernel"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 DEPENDS += "${@bb.utils.contains('ARCH', 'x86', 'elfutils-native', '', d)}"
-DEPENDS += "openssl-native util-linux-native"
+DEPENDS += "openssl-native util-linux-native coreutils-native"
 
-PV = "${LINUX_VERSION}"
-KBRANCH = "linux-sl-6.6"
+PV = "6.11.0-rc7"
+KBRANCH = "linux-sl-amd"
 KMETA = "kernel-meta"
 SRC_URI = "\
     git://github.com/TrenchBoot/linux.git;protocol=https;branch=${KBRANCH};name=machine; \
@@ -21,10 +21,10 @@ SRC_URI = "\
     file://debug.cfg \
     file://efi.cfg \
 "
-SRCREV_machine = "6232d27cf74aa6ace46ee362d2172d18bdf70282"
+SRCREV_machine = "bd46a2617f584046eac7b1d9c7842dc0aff013fd"
 SRCREV_meta = "49698cadd79745fa26aa7ef507c16902250c1750"
 
-LINUX_VERSION ?= "6.6.1"
+LINUX_VERSION ?= "6.11-rc7"
 
 KCONFIG_MODE = "--alldefconfig"
 

--- a/recipes-support/skl/skl/0001-head-pass-entry-point-address-in-ebx-to-payload.patch
+++ b/recipes-support/skl/skl/0001-head-pass-entry-point-address-in-ebx-to-payload.patch
@@ -1,0 +1,25 @@
+From 4be25b0b35cf38d0dc3c3c6db674bfc36e6aa82f Mon Sep 17 00:00:00 2001
+From: Sergii Dmytruk <sergii.dmytruk@3mdeb.com>
+Date: Wed, 13 Nov 2024 19:30:48 +0200
+Subject: [PATCH] head: pass entry point address in %ebx to payload
+
+Signed-off-by: Sergii Dmytruk <sergii.dmytruk@3mdeb.com>
+---
+ head.S | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/head.S b/head.S
+index 4c57eed..ba14ae4 100644
+--- a/head.S
++++ b/head.S
+@@ -246,7 +246,7 @@ GLOBAL(_entry)
+ 	 */
+ 	/* Linux expects Zero Page address in %esi, it is already there */
+ 	/* Multiboot2 expects MBI address in %ebx and magic number in %eax */
+-	mov	%esi, %ebx
++	mov	%edi, %ebx
+ 	mov	$MULTIBOOT2_BOOTLOADER_MAGIC, %eax
+ 	/* Simple payload expects argument on stack followed by return address */
+ 	push	%esi
+-- 
+2.47.0

--- a/recipes-support/skl/skl_git.bb
+++ b/recipes-support/skl/skl_git.bb
@@ -7,9 +7,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4641e94ec96f98fabc56ff9cc48be14b"
 
 DEPENDS = "util-linux-native"
 
-SRC_URI = "git://github.com/TrenchBoot/secure-kernel-loader.git;protocol=https;nobranch=1;name=skl"
-# v0.4.0 tag
-SRCREV = "18f535843b22e784dbbc8e1ec11d8dc099b3d0fe"
+SRC_URI = "git://github.com/TrenchBoot/secure-kernel-loader.git;protocol=https;branch=${BRANCH};name=skl"
+BRANCH = "master"
+SRCREV = "1cc0a75191ed0309a6cc660533a8e044f40019d3"
 
 TUNE_CCARGS:remove = "-msse3 -mfpmath=sse"
 

--- a/recipes-support/skl/skl_git.bb
+++ b/recipes-support/skl/skl_git.bb
@@ -8,6 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4641e94ec96f98fabc56ff9cc48be14b"
 DEPENDS = "util-linux-native"
 
 SRC_URI = "git://github.com/TrenchBoot/secure-kernel-loader.git;protocol=https;branch=${BRANCH};name=skl"
+SRC_URI:append = " file://0001-head-pass-entry-point-address-in-ebx-to-payload.patch"
 BRANCH = "master"
 SRCREV = "1cc0a75191ed0309a6cc660533a8e044f40019d3"
 

--- a/scripts/tb.sh
+++ b/scripts/tb.sh
@@ -272,9 +272,9 @@ deploy_recipe() {
             kernel_path="$genericx86_path/linux-tb/$recipe_version"
             ${SUDO} rsync -chavP --exclude "boot" \
                 "$kernel_path/image/" "$DESTINATION_ARG"
-            ${SUDO} rsync -chrtvP --inplace \
+            ${SUDO} rsync -chrtvPL --inplace \
                 "$kernel_path/deploy-linux-tb/bzImage-initramfs-genericx86-64.bin" "$DESTINATION_ARG/boot"
-            ${SUDO} rsync -chrtvP --inplace \
+            ${SUDO} rsync -chrtvPL --inplace \
                 "$kernel_path/deploy-linux-tb/bzImage-initramfs-genericx86-64.bin" "$DESTINATION_ARG/boot/bzImage"
             ;;
         tb-full-image)

--- a/scripts/tb.sh
+++ b/scripts/tb.sh
@@ -216,7 +216,7 @@ update_grub() {
             fi
             kas-container --runtime-args \
                 "--device=$disk_device:$disk_device -v $DESTINATION_ARG:/mnt" \
-                shell meta-trenchboot/kas-tb-full.yml -c " \
+                shell "$KAS_YAML" -c " \
                   $verbose &&
                   cd /build/tmp/sysroots-components/x86_64/grub-native/usr &&
                   sudo ./bin/grub-mkimage -p '(hd0,msdos1)/grub' -d $grub_dir/i386-pc \
@@ -241,7 +241,7 @@ deploy_recipe() {
     local genericx86_path="$work_dir/genericx86_64-tb-linux"
 
     recipe_version=$(
-        kas-container shell meta-trenchboot/kas-tb-full.yml \
+        kas-container shell "$KAS_YAML" \
                 -c "devtool latest-version $RECIPE_ARG" 2>&1 |
             sed -n 's/INFO: Current version: //p'
         )


### PR DESCRIPTION
Xen is removed until https://github.com/3mdeb/meta-trenchboot/issues/44 is clarified.